### PR TITLE
reduce GPU memery

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,6 +1,6 @@
 ## Environment setup
 
-#### Ubuntu 22.04.3 LTS, NVIDIA A100/H100 (80GB), CUDA=12.1
+#### Ubuntu 22.04.3 LTS, NVIDIA A6000 (40G), A100/H100 (80GB), CUDA=12.1
 
 - Please refer to [Diffuser GPU Memory](https://huggingface.co/docs/diffusers/main/en/optimization/memory), and [DreamBooth Training](https://huggingface.co/docs/diffusers/v0.30.3/training/dreambooth?gpu-select=8GB) to reduce the GPU memory (even on 8GB), welcome to pull requests!
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -6,7 +6,8 @@ export HF_HOME="/is/cluster/yxiu/.cache"
 # CUDA
 export CUDA_HOME="/is/software/nvidia/cuda-12.1"
 export PYTORCH_KERNEL_CACHE_PATH="/is/cluster/yxiu/.cache/torch"
-export PYOPENGL_PLATFORM="egl"
+# export PYOPENGL_PLATFORM="egl"
+export PYOPENGL_PLATFORM="osmesa"
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 
 # OPENAI API Key: https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,7 +17,7 @@ rm -rf ${EXP_DIR}/text_encoder
 rm -rf ${EXP_DIR}/unet
 rm -rf ${EXP_DIR}/img_logs
 
-python multi_concepts/train.py \
+accelerate launch multi_concepts/train.py \
   --pretrained_model_name_or_path $BASE_MODEL \
   --project_name ${SUBJECT_NAME} \
   --instance_data_dir ${INPUT_DIR}  \


### PR DESCRIPTION
During Dreambooth fine-tuning, we require approximately 16GB. In the SDS phase, we need around 40GB.