### PR TITLE
remove set_grads_to_none to avoid run bug

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -49,7 +49,7 @@ accelerate launch multi_concepts/train.py \
   --mixed_precision fp16 \
   --gradient_checkpointing \
   --use_8bit_adam \
-  --set_grads_to_none \
+  # --set_grads_to_none \
   # --use_shape_description \
   # --no_prior_preservation \
 


### PR DESCRIPTION
issue https://github.com/YuliangXiu/PuzzleAvatar/issues/10

ref https://huggingface.co/docs/diffusers/v0.20.0/en/training/custom_diffusion

> To save even more memory, pass the --set_grads_to_none argument to the script. This will set grads to None instead of zero. However, be aware that it changes certain behaviors, so if you start experiencing any problems, remove this argument.

current booth stage:  ~24GB VRAM 

